### PR TITLE
signature-help

### DIFF
--- a/client/src/ccs/formattingControl.ts
+++ b/client/src/ccs/formattingControl.ts
@@ -1,0 +1,79 @@
+const skipUris = new Set<string>();
+const autoSkipUris = new Set<string>();
+const manualAllowances = new Map<string, number>();
+const compileBlocks = new Map<string, number>();
+
+const manualAllowanceMs = 1000;
+const compileBlockMs = 8000;
+
+function purgeExpiredEntries(uri: string, now: number): void {
+        const manualExpiry = manualAllowances.get(uri);
+        if (manualExpiry !== undefined && manualExpiry < now) {
+                manualAllowances.delete(uri);
+        }
+
+        const compileExpiry = compileBlocks.get(uri);
+        if (compileExpiry !== undefined && compileExpiry < now) {
+                compileBlocks.delete(uri);
+        }
+}
+
+export function scheduleFormatSkip(uri: string): void {
+        skipUris.add(uri);
+        autoSkipUris.add(uri);
+        manualAllowances.delete(uri);
+}
+
+export function consumeFormatSkip(uri: string): boolean {
+        const now = Date.now();
+        purgeExpiredEntries(uri, now);
+
+        const manualExpiry = manualAllowances.get(uri);
+        if (manualExpiry !== undefined && manualExpiry >= now) {
+                skipUris.delete(uri);
+                autoSkipUris.delete(uri);
+                return false;
+        }
+
+        if (compileBlocks.has(uri)) {
+                return true;
+        }
+
+        if (skipUris.has(uri)) {
+                skipUris.delete(uri);
+                autoSkipUris.delete(uri);
+                return true;
+        }
+
+        return false;
+}
+
+export function clearFormatSkip(uri: string): void {
+        skipUris.delete(uri);
+        autoSkipUris.delete(uri);
+        manualAllowances.delete(uri);
+}
+
+export function removeFormatSkip(uri: string): void {
+        skipUris.delete(uri);
+        autoSkipUris.delete(uri);
+        manualAllowances.delete(uri);
+        compileBlocks.delete(uri);
+}
+
+export function blockFormatAfterCompile(uri: string): void {
+        skipUris.add(uri);
+        autoSkipUris.delete(uri);
+        compileBlocks.set(uri, Date.now() + compileBlockMs);
+        manualAllowances.delete(uri);
+}
+
+export function allowManualFormat(uri: string): void {
+        const now = Date.now();
+        if (autoSkipUris.has(uri)) {
+                return;
+        }
+        manualAllowances.set(uri, now + manualAllowanceMs);
+        compileBlocks.delete(uri);
+        skipUris.delete(uri);
+}

--- a/server/src/ccs/hover/classSupport.ts
+++ b/server/src/ccs/hover/classSupport.ts
@@ -1,0 +1,188 @@
+import { Hover, Position, Range, SignatureInformation } from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+import {
+        beautifyFormalSpec,
+        determineActiveParam,
+        findOpenParen,
+        getClassMemberContext,
+        makeRESTRequest,
+        quoteUDLIdentifier
+} from '../../utils/functions';
+import { ServerSpec, compressedline } from '../../utils/types';
+import * as ld from '../../utils/languageDefinitions';
+import { buildRoutineDocumentation, formalSpecToParamsArr } from '../signatureHelp/routineSupport';
+
+export type MethodSignatureDetails = {
+        signature: SignatureInformation;
+        start: Position;
+};
+
+async function getMethodSignatureDetails(
+        doc: TextDocument,
+        parsed: compressedline[],
+        parenLine: number,
+        parenToken: number,
+        server: ServerSpec
+): Promise<MethodSignatureDetails | null> {
+        const tokens = parsed[parenLine];
+        if (tokens === undefined || tokens[parenToken] === undefined) {
+                return null;
+        }
+        const calleeToken = tokens[parenToken - 1];
+        if (calleeToken === undefined) {
+                return null;
+        }
+        if (
+                calleeToken.l !== ld.cos_langindex ||
+                ![ld.cos_method_attrindex, ld.cos_mem_attrindex].includes(calleeToken.s)
+        ) {
+                return null;
+        }
+
+        const memberRange = Range.create(
+                parenLine,
+                calleeToken.p,
+                parenLine,
+                calleeToken.p + calleeToken.c
+        );
+        const member = doc.getText(memberRange);
+        const unquotedName = quoteUDLIdentifier(member, 0);
+
+        const memberContext = await getClassMemberContext(doc, parsed, parenToken - 2, parenLine, server);
+        if (memberContext.baseclass === '') {
+                return null;
+        }
+
+        const queryData = member === '%New'
+                ? {
+                        query: 'SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)',
+                        parameters: [memberContext.baseclass, unquotedName, '%OnNew']
+                }
+                : {
+                        query: 'SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?',
+                        parameters: [memberContext.baseclass, unquotedName]
+                };
+        const respData = await makeRESTRequest('POST', 1, '/action/query', server, queryData);
+        const rows: any[] | undefined = respData?.data?.result?.content;
+        if (!Array.isArray(rows) || rows.length === 0) {
+                return null;
+        }
+
+        const start = Position.create(parenLine, tokens[parenToken].p + 1);
+
+        if (member === '%New') {
+                if (rows.length === 2 && rows[1].Origin !== '%Library.RegisteredObject') {
+                        const formalSpec = typeof rows[1].FormalSpec === 'string' ? rows[1].FormalSpec : '';
+                        if (formalSpec === '') {
+                                return null;
+                        }
+                        const raw = beautifyFormalSpec(formalSpec);
+                        const signature: SignatureInformation = {
+                                label: raw,
+                                parameters: formalSpecToParamsArr(raw)
+                        };
+                        signature.label += ` As ${memberContext.baseclass}`;
+                        return { signature, start };
+                }
+                return null;
+        }
+
+        let methodRow = rows[0] ?? {};
+        const stubValue = typeof methodRow.Stub === 'string' ? methodRow.Stub : '';
+        if (stubValue !== '') {
+                const stubParts = stubValue.split('.');
+                if (stubParts.length >= 3) {
+                        let stubQuery = '';
+                        if (stubParts[2] === 'i') {
+                                stubQuery = 'SELECT Description, FormalSpec, ReturnType FROM %Dictionary.CompiledIndexMethod WHERE Name = ? AND parent->Parent = ? AND parent->Name = ?';
+                        } else if (stubParts[2] === 'q') {
+                                stubQuery = 'SELECT Description, FormalSpec, ReturnType FROM %Dictionary.CompiledQueryMethod WHERE Name = ? AND parent->Parent = ? AND parent->Name = ?';
+                        } else if (stubParts[2] === 'a') {
+                                stubQuery = 'SELECT Description, FormalSpec, ReturnType FROM %Dictionary.CompiledPropertyMethod WHERE Name = ? AND parent->Parent = ? AND parent->Name = ?';
+                        } else if (stubParts[2] === 'n') {
+                                stubQuery = 'SELECT Description, FormalSpec, ReturnType FROM %Dictionary.CompiledConstraintMethod WHERE Name = ? AND parent->Parent = ? AND parent->Name = ?';
+                        }
+                        if (stubQuery !== '') {
+                                const stubResp = await makeRESTRequest('POST', 1, '/action/query', server, {
+                                        query: stubQuery,
+                                        parameters: [stubParts[1], memberContext.baseclass, stubParts[0]]
+                                });
+                                const stubRows: any[] | undefined = stubResp?.data?.result?.content;
+                                if (Array.isArray(stubRows) && stubRows.length > 0) {
+                                        methodRow = stubRows[0];
+                                }
+                        }
+                }
+        }
+
+        const formalSpec = typeof methodRow.FormalSpec === 'string' ? methodRow.FormalSpec : '';
+        if (formalSpec === '') {
+                return null;
+        }
+
+        const raw = beautifyFormalSpec(formalSpec);
+        const signature: SignatureInformation = {
+                label: raw,
+                parameters: formalSpecToParamsArr(raw)
+        };
+        const returnType = typeof methodRow.ReturnType === 'string' ? methodRow.ReturnType : '';
+        if (['%Open', '%OpenId'].includes(member)) {
+                signature.label += ` As ${memberContext.baseclass}`;
+        } else if (returnType !== '') {
+                signature.label += ` As ${returnType}`;
+        }
+
+        return { signature, start };
+}
+
+export async function getClassMethodHover(
+        doc: TextDocument,
+        parsed: compressedline[],
+        position: Position,
+        tokenIndex: number,
+        server: ServerSpec
+): Promise<Hover | null> {
+        const [parenLine, parenToken] = findOpenParen(doc, parsed, position.line, tokenIndex);
+        if (parenLine === -1 || parenToken === -1) {
+                return null;
+        }
+
+        const details = await getMethodSignatureDetails(doc, parsed, parenLine, parenToken, server);
+        if (details === null) {
+                return null;
+        }
+
+        const startPos = details.start;
+        const signature = details.signature;
+        const paramInfos = signature.parameters ?? [];
+
+        let activeIndex: number | null = null;
+        if (
+                position.line < startPos.line ||
+                (position.line === startPos.line && position.character < startPos.character)
+        ) {
+                activeIndex = paramInfos.length > 0 ? 0 : null;
+        } else {
+                const spanText = doc.getText(Range.create(startPos, position));
+                const computed = determineActiveParam(spanText);
+                if (paramInfos.length > 0) {
+                        activeIndex = Math.min(Math.max((computed ?? 0), 0), paramInfos.length - 1);
+                } else {
+                        activeIndex = null;
+                }
+        }
+
+        const docContent = buildRoutineDocumentation(
+                signature,
+                activeIndex,
+                { context: 'hover', showHeaderInHover: false })
+        if (docContent === undefined) {
+                return null;
+        }
+
+        return {
+                contents: docContent,
+                range: Range.create(position, position)
+        };
+}

--- a/server/src/ccs/hover/routineSupport.ts
+++ b/server/src/ccs/hover/routineSupport.ts
@@ -1,0 +1,82 @@
+import { Hover, Position, Range } from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { determineActiveParam, findOpenParen } from '../../utils/functions';
+import { ServerSpec, compressedline } from '../../utils/types';
+import * as ld from '../../utils/languageDefinitions';
+import {
+        buildRoutineDocumentation,
+        getRoutineSignatureDetails
+} from '../signatureHelp/routineSupport';
+
+/** Try to build a hover result for an extrinsic routine call parameter at the given location. */
+export async function getRoutineHover(
+        doc: TextDocument,
+        parsed: compressedline[],
+        position: Position,
+        tokenIndex: number,
+        uri: string,
+        server: ServerSpec
+): Promise<Hover | null> {
+        const token = parsed[position.line]?.[tokenIndex];
+        if (token === undefined) {
+                return null;
+        }
+
+        if (token.l !== ld.cos_langindex) {
+                return null;
+        }
+        if ([ld.cos_comment_attrindex, ld.cos_dcom_attrindex, ld.cos_str_attrindex].includes(token.s)) {
+                return null;
+        }
+
+        const [parenLine, parenToken] = findOpenParen(doc, parsed, position.line, tokenIndex);
+        if (parenLine === -1 || parenToken === -1) {
+                return null;
+        }
+
+        const routineDetails = await getRoutineSignatureDetails(
+                doc,
+                parsed,
+                parenLine,
+                parenToken,
+                uri,
+                server
+        );
+        if (routineDetails === null) {
+                return null;
+        }
+
+        const startPos = routineDetails.start;
+        let activeIndex: number | null = null;
+        if (
+                position.line < startPos.line ||
+                (position.line === startPos.line && position.character < startPos.character)
+        ) {
+                activeIndex = 0;
+        } else {
+                const spanText = doc.getText(Range.create(startPos, position));
+                const computed = determineActiveParam(spanText);
+                if (routineDetails.signature.parameters.length > 0) {
+                        activeIndex = Math.min(
+                                Math.max((computed ?? 0), 0),
+                                routineDetails.signature.parameters.length - 1
+                        );
+                } else {
+                        activeIndex = null;
+                }
+        }
+
+        const docContent = buildRoutineDocumentation(
+                routineDetails.signature,
+                activeIndex,
+                { context: 'hover', showHeaderInHover: false })
+        if (docContent === undefined) {
+                return null;
+        }
+
+        return {
+                contents: docContent,
+                range: Range.create(position, position)
+        };
+}

--- a/server/src/ccs/signatureHelp/routineSupport.ts
+++ b/server/src/ccs/signatureHelp/routineSupport.ts
@@ -1,0 +1,404 @@
+import { MarkupContent, MarkupKind, ParameterInformation, Position, Range, SignatureInformation } from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { createDefinitionUri, getTextForUri, makeRESTRequest } from '../../utils/functions';
+import { ServerSpec, compressedline } from '../../utils/types';
+
+/** Remove anything following the first semicolon in a routine line. */
+function stripRoutineComment(line: string): string {
+        const commentIdx = line.indexOf(';');
+        return commentIdx === -1 ? line : line.slice(0, commentIdx);
+}
+
+/** Split a routine parameter list into individual parameters. */
+function splitRoutineParams(paramStr: string): string[] {
+        const normalized = paramStr.replace(/\r?\n/g, ' ');
+        if (normalized.trim() === '') {
+                return [];
+        }
+        const result: string[] = [];
+        let current = '';
+        let inQuote = false;
+        let parenDepth = 0;
+        for (let i = 0; i < normalized.length; i++) {
+                const char = normalized.charAt(i);
+                if (char === '"' && normalized.charAt(i - 1) !== '\\') {
+                        inQuote = !inQuote;
+                        current += char;
+                        continue;
+                }
+                if (!inQuote) {
+                        if (char === '(') {
+                                parenDepth++;
+                                current += char;
+                                continue;
+                        }
+                        if (char === ')' && parenDepth > 0) {
+                                parenDepth--;
+                                current += char;
+                                continue;
+                        }
+                        if (char === ',' && parenDepth === 0) {
+                                result.push(current.trim());
+                                current = '';
+                                continue;
+                        }
+                }
+                current += char;
+        }
+        const finalParam = current.trim();
+        if (finalParam.length) {
+                result.push(finalParam);
+        }
+        return result.filter((param) => param.length > 0);
+}
+
+type RoutineCallContext = {
+        label: string;
+        routine: string;
+};
+
+function extractRoutineCall(callPrefix: string): RoutineCallContext | null {
+        const prefix = callPrefix.trimEnd();
+
+        const extrinsicMatch = prefix.match(/\$\$([%A-Za-z][\w%]*)(?:\s*\^\s*([%A-Za-z][\w%]*))?$/);
+        if (extrinsicMatch) {
+                return {
+                        label: extrinsicMatch[1],
+                        routine: extrinsicMatch[2] ?? ''
+                };
+        }
+
+        const doLabelMatch = prefix.match(/\b[Dd][Oo]\b\s+([%A-Za-z][\w%]*)(?:\s*\^\s*([%A-Za-z][\w%]*))?$/);
+        if (doLabelMatch) {
+                return {
+                        label: doLabelMatch[1],
+                        routine: doLabelMatch[2] ?? ''
+                };
+        }
+
+        const doRoutineMatch = prefix.match(/\b[Dd][Oo]\b\s*\^\s*([%A-Za-z][\w%]*)$/);
+        if (doRoutineMatch) {
+                return {
+                        label: doRoutineMatch[1],
+                        routine: doRoutineMatch[1]
+                };
+        }
+
+        return null;
+}
+
+/** Build the ParameterInformation array for a routine signature label. */
+export function routineParameterInfos(signatureLabel: string, params: string[]): ParameterInformation[] {
+        if (params.length === 0) {
+                return [];
+        }
+        const result: ParameterInformation[] = [];
+        let currentPos = signatureLabel.indexOf('(') + 1;
+        params.forEach((param, idx) => {
+                const trimmed = param.trim();
+                const start = currentPos;
+                const end = start + trimmed.length;
+                result.push(ParameterInformation.create([start, end]));
+                currentPos = end;
+                if (idx < params.length - 1) {
+                        currentPos += 2; // Account for the comma and following space
+                }
+        });
+        return result;
+}
+
+/** Returns the [start,end] tuples for all parameters in a formal spec string. */
+export function formalSpecToParamsArr(formalSpec: string): ParameterInformation[] {
+        const result: ParameterInformation[] = [];
+        if (formalSpec.replace(/\s+/g, "") === "()") {
+                return result;
+        }
+        let currentParamStart = 1;
+        let openParenCount = 0;
+        let openBraceCount = 0;
+        let inQuote = false;
+        Array.from(formalSpec).forEach((char: string, idx: number) => {
+                switch (char) {
+                        case "{":
+                                if (!inQuote) {
+                                        openBraceCount++;
+                                }
+                                break;
+                        case "}":
+                                if (!inQuote) {
+                                        openBraceCount--;
+                                }
+                                break;
+                        case "(":
+                                if (!inQuote) {
+                                        openParenCount++;
+                                }
+                                break;
+                        case ")":
+                                if (!inQuote) {
+                                        openParenCount--;
+                                }
+                                break;
+                        case "\"":
+                                inQuote = !inQuote;
+                                break;
+                        case ",":
+                                if (!inQuote && !openBraceCount && openParenCount === 1) {
+                                        result.push(ParameterInformation.create([currentParamStart, idx]));
+                                        currentParamStart = idx + 1;
+                                }
+                                break;
+                        default:
+                                break;
+                }
+        });
+        result.push(ParameterInformation.create([currentParamStart, formalSpec.length - 1]));
+        return result;
+}
+
+export type RoutineSignatureDetails = {
+        signature: SignatureInformation;
+        start: Position;
+        parameters: string[];
+};
+
+/** Try to build signature help details for an extrinsic routine call preceding the paren at (line, token). */
+export async function getRoutineSignatureDetails(
+        doc: TextDocument,
+        parsed: compressedline[],
+        parenLine: number,
+        parenToken: number,
+        paramsUri: string,
+        server: ServerSpec
+): Promise<RoutineSignatureDetails | null> {
+        if (parsed[parenLine]?.[parenToken] === undefined) {
+                return null;
+        }
+        const parenPos = parsed[parenLine][parenToken].p;
+        const callPrefix = doc.getText(Range.create(Position.create(parenLine, 0), Position.create(parenLine, parenPos)));
+        const callContext = extractRoutineCall(callPrefix);
+        if (callContext === null) {
+                return null;
+        }
+        const { label } = callContext;
+        let routineName = callContext.routine ?? '';
+
+        let currentRoutine = '';
+        if (["objectscript", "objectscript-int"].includes(doc.languageId) && parsed[0]?.length > 1) {
+                currentRoutine = doc.getText(
+                        Range.create(
+                                Position.create(0, parsed[0][1].p),
+                                Position.create(0, parsed[0][1].p + parsed[0][1].c)
+                        )
+                );
+        }
+        if (routineName === '') {
+                routineName = currentRoutine;
+        }
+        if (routineName === '') {
+                return null;
+        }
+
+        let routineLines: string[] = [];
+        if (routineName === currentRoutine && ["objectscript", "objectscript-int"].includes(doc.languageId)) {
+                routineLines = doc.getText().split(/\r?\n/);
+        } else {
+                const indexResp = await makeRESTRequest('POST', 1, '/action/index', server, [`${routineName}.int`]);
+                if (!Array.isArray(indexResp?.data?.result?.content) || indexResp.data.result.content.length === 0) {
+                        return null;
+                }
+                const routineEntry = indexResp.data.result.content[0];
+                if (routineEntry.status !== '') {
+                        return null;
+                }
+                let ext = '.int';
+                if (
+                        Array.isArray(routineEntry.others) &&
+                        routineEntry.others.some((other: string) => other.slice(-3).toLowerCase() === 'mac')
+                ) {
+                        ext = '.mac';
+                }
+                const routineUri = await createDefinitionUri(paramsUri, routineName, ext);
+                if (routineUri === '') {
+                        return null;
+                }
+                routineLines = await getTextForUri(routineUri, server);
+                if (!Array.isArray(routineLines) || routineLines.length === 0) {
+                        return null;
+                }
+        }
+
+        let labelLineIndex = -1;
+        for (let i = 0; i < routineLines.length; i++) {
+                const line = routineLines[i];
+                if (!line.startsWith(label)) {
+                        continue;
+                }
+                const trimmed = line.trimEnd();
+                const afterLabel = line.slice(label.length);
+                if (
+                        trimmed.length === label.length ||
+                        afterLabel.startsWith(' ') ||
+                        afterLabel.startsWith('\t') ||
+                        afterLabel.startsWith('(') ||
+                        afterLabel.startsWith(';') ||
+                        afterLabel.startsWith('##;') ||
+                        afterLabel.startsWith('//') ||
+                        afterLabel.startsWith('/*')
+                ) {
+                        labelLineIndex = i;
+                        break;
+                }
+        }
+        if (labelLineIndex === -1) {
+                return null;
+        }
+
+        const labelLine = routineLines[labelLineIndex];
+        const noComment = stripRoutineComment(labelLine);
+        const openParenIdx = noComment.indexOf('(');
+        let paramString = '';
+        if (openParenIdx >= 0) {
+                let remainder = noComment.slice(openParenIdx + 1);
+                let closeIdx = remainder.indexOf(')');
+                let searchIdx = labelLineIndex;
+                while (closeIdx === -1) {
+                        searchIdx++;
+                        if (searchIdx >= routineLines.length) {
+                                break;
+                        }
+                        const nextLineRaw = stripRoutineComment(routineLines[searchIdx]);
+                        if (nextLineRaw.length && /^[A-Za-z%]/.test(nextLineRaw.charAt(0))) {
+                                break;
+                        }
+                        const nextTrimmed = nextLineRaw.trim();
+                        if (nextTrimmed.length) {
+                                if (remainder.length && !remainder.endsWith(' ') && !nextTrimmed.startsWith(',')) {
+                                        remainder += ' ';
+                                }
+                                remainder += nextTrimmed;
+                        }
+                        closeIdx = remainder.indexOf(')');
+                }
+                if (closeIdx !== -1) {
+                        paramString = remainder.slice(0, closeIdx);
+                } else {
+                        paramString = remainder.trim();
+                }
+        }
+
+        const params = splitRoutineParams(paramString);
+        const paramsText = params.join(', ');
+        const signatureLabel = `${label}(${paramsText})`;
+        const signature: SignatureInformation = {
+                label: signatureLabel,
+                parameters: routineParameterInfos(signatureLabel, params)
+        };
+
+        return {
+                signature,
+                start: Position.create(parenLine, parsed[parenLine][parenToken].p + 1),
+                parameters: params
+        };
+}
+
+function escapeHtml(text: string): string {
+        return text
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+}
+
+export function buildRoutineDocumentation(
+        signature: SignatureInformation,
+        activeIndex: number | null,
+        options?: {
+                context?: 'hover' | 'signature';
+                boldParameter?: boolean;
+                // opcional: mostrar o cabeçalho (bloco de código) no hover
+                showHeaderInHover?: boolean;
+        }
+): MarkupContent | undefined {
+        const paramInfos = signature.parameters ?? [];
+        const isHover = options?.context === 'hover';
+        const isSignature = options?.context === 'signature';
+        const boldParam = options?.boldParameter === true;
+        const showHeaderInHover = options?.showHeaderInHover ?? true;
+
+        const clamp = (i: number) =>
+                paramInfos.length ? Math.min(Math.max(i, 0), paramInfos.length - 1) : 0;
+
+        const getParamText = (i: number) => {
+                const info = paramInfos[i];
+                if (!info) return '';
+                if (Array.isArray(info.label)) {
+                        const [s, e] = info.label;
+                        return s < e ? signature.label.slice(s, e) : '';
+                }
+                return typeof info.label === 'string' ? info.label : '';
+        };
+
+        const esc = (s: string) =>
+                s.replace(/[<&>]/g, m => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[m]!));
+
+        // assinatura com o parâmetro ativo em `inline code`
+        const renderSignatureWithInlineParam = (label: string, i: number) => {
+                const info = paramInfos[i];
+                if (!info) return esc(label);
+
+                if (Array.isArray(info.label)) {
+                        const [s, e] = info.label;
+                        if (s < e) {
+                                const pre = esc(label.slice(0, s));
+                                const mid = esc(label.slice(s, e));
+                                const pos = esc(label.slice(e));
+                                const midCode = boldParam ? `**\`${mid}\`**` : `\`${mid}\``;
+                                return `${pre}${midCode}${pos}`;
+                        }
+                        return esc(label);
+                }
+
+                if (typeof info.label === 'string' && info.label) {
+                        const safeLabel = esc(label);
+                        const needle = esc(info.label);
+                        const k = safeLabel.indexOf(needle);
+                        if (k >= 0) {
+                                const pre = safeLabel.slice(0, k);
+                                const pos = safeLabel.slice(k + needle.length);
+                                const midCode = boldParam ? `**\`${needle}\`**` : `\`${needle}\``;
+                                return `${pre}${midCode}${pos}`;
+                        }
+                }
+                return esc(label);
+        };
+
+        const idx = clamp(activeIndex ?? 0);
+        const pText = getParamText(idx);
+        const pEsc = esc(pText);
+        const pInline = boldParam ? `**\`${pEsc}\`**` : `\`${pEsc}\``;
+
+        const lines: string[] = [];
+
+        if (isHover && showHeaderInHover) {
+                // cabeçalho tipo “bloco de código” no hover
+                lines.push('```');
+                lines.push(signature.label); // sem escape — preserve exatamente a assinatura
+                lines.push('```');
+                lines.push('');
+        }
+
+        // ⛔ NO SIGNATURE: NÃO renderiza a linha “do meio”
+        if (!isSignature) {
+                // hover: mantém a linha “signature-like”
+                lines.push(renderSignatureWithInlineParam(signature.label, idx));
+                lines.push('');
+        }
+
+        // “Parâmetro na origem” em ambos os contextos
+        lines.push(pText ? `Parâmetro na origem: ${pInline}` : 'Parâmetro na origem:');
+
+        return { kind: MarkupKind.Markdown, value: lines.join('\n') };
+}

--- a/server/src/providers/signatureHelp.ts
+++ b/server/src/providers/signatureHelp.ts
@@ -1,8 +1,9 @@
 import { Position, SignatureHelp, SignatureHelpParams, SignatureHelpTriggerKind, SignatureInformation, Range, MarkupKind, ParameterInformation } from 'vscode-languageserver/node';
 import { getServerSpec, getLanguageServerSettings, makeRESTRequest, getMacroContext, findFullRange, getClassMemberContext, beautifyFormalSpec, documaticHtmlToMarkdown, findOpenParen, getParsedDocument, quoteUDLIdentifier, determineActiveParam } from '../utils/functions';
-import { ServerSpec, SignatureHelpDocCache, SignatureHelpMacroContext } from '../utils/types';
+import { ServerSpec, SignatureHelpDocCache, SignatureHelpMacroContext, compressedline } from '../utils/types';
 import { documents } from '../utils/variables';
 import * as ld from '../utils/languageDefinitions';
+import { buildRoutineDocumentation, formalSpecToParamsArr, getRoutineSignatureDetails } from '../ccs/signatureHelp/routineSupport';
 
 /**
  * Cache of the macro context info required to do a macro expansion when the selected parameter changes.
@@ -13,7 +14,7 @@ var signatureHelpMacroCache: SignatureHelpMacroContext;
  * Cache of the documentation content sent for the last triggered SignatureHelp.
  */
 var signatureHelpDocumentationCache: SignatureHelpDocCache | undefined = undefined;
- 
+
 /**
  * The start position of the active SignatureHelp.
  */
@@ -32,10 +33,11 @@ const emphasizeSuffix: string = "@@@@@";
  * @param arg The one-indexed number of the argument to emphasize.
  */
 function emphasizeArgument(arglist: string, arg: number): string {
-	var numargs: number = arglist.split(" ").length;
+	const normalized = arglist.replace(/\u00A0/g, " ");
+	var numargs: number = normalized.split(" ").length;
 	if (arg > numargs) {
 		// The given argument doesn't exist in the list
-		return arglist.replace(/\s+/g,"");
+		return normalized.replace(/\s+/g, "");
 	}
 
 	var start: number = -1; // inclusive
@@ -44,101 +46,67 @@ function emphasizeArgument(arglist: string, arg: number): string {
 	var lastspace: number = 0;
 	if (arg === numargs) {
 		// The last argument always ends at the second-to-last position
-		end = arglist.length - 1;
-		if (numargs > 1) start = arglist.lastIndexOf(" ") + 1;
+		end = normalized.length - 1;
+		if (numargs > 1) start = normalized.lastIndexOf(" ") + 1;
 	}
 	if (arg === 1) {
 		// The first argument always starts at position 1
 		start = 1;
 		if (end === -1) {
 			// Find the first space
-			end = arglist.indexOf(" ") - 1;
+			end = normalized.indexOf(" ") - 1;
 		}
 	}
 	if (start !== -1 && end !== -1) {
 		// Do the replacement
-		return (arglist.slice(0,start) + emphasizePrefix + arglist.slice(start,end) + emphasizeSuffix + arglist.slice(end)).replace(/\s+/g,"");
-	}
-	else {
+		return (arglist.slice(0, start) + emphasizePrefix + arglist.slice(start, end) + emphasizeSuffix + arglist.slice(end)).replace(/\s+/g, "");
+	} else {
 		// Find the unknown positions
 		var result = arglist;
-		while (arglist.indexOf(" ",lastspace+1) !== -1) {
-			const thisspace = arglist.indexOf(" ",lastspace);
+		while (normalized.indexOf(" ", lastspace + 1) !== -1) {
+			const thisspace = normalized.indexOf(" ", lastspace);
 			spacesfound++;
 			if (arg === spacesfound + 1) {
 				// This is the space before the argument
 				start = thisspace + 1;
 				if (end === -1) {
 					// Look for the next space
-					end = arglist.indexOf(" ",start) - 1;
+					end = normalized.indexOf(" ", start) - 1;
 				}
-				result = arglist.slice(0,start) + emphasizePrefix + arglist.slice(start,end) + emphasizeSuffix + arglist.slice(end);
+				result = arglist.slice(0, start) + emphasizePrefix + arglist.slice(start, end) + emphasizeSuffix + arglist.slice(end);
 				break;
 			}
 			lastspace = thisspace;
 		}
-		return result.replace(/\s+/g,"");
+		return result.replace(/\s+/g, "");
 	}
 };
 
 /** Use HTML to display `exp` as a code block with the empasized argument rendered bold, italic and underlined. */
 function markdownifyExpansion(exp: string[]): string {
 	return "<pre>\n" + exp.map(e => e.trimEnd()).join("\n")
-		.replace(new RegExp(emphasizePrefix,"g"),"<b><i><u>")
-		.replace(new RegExp(emphasizeSuffix,"g"),"</u></i></b>") + "\n</pre>";
-}
-
-/** Returns the [start,end] tuples for all parameters in `formalSpec` */
-function formalSpecToParamsArr(formalSpec: string): ParameterInformation[] {
-	const result: ParameterInformation[] = [];
-	if (formalSpec.replace(/\s+/g,"") == "()") return result; // No parameters
-	let currentParamStart = 1, openParenCount = 0, openBraceCount = 0, inQuote = false;
-	Array.from(formalSpec).forEach((char: string, idx: number) => {
-		switch (char) {
-			case "{":
-				if (!inQuote) openBraceCount++;
-				break;
-			case "}":
-				if (!inQuote) openBraceCount--;
-				break;
-			case "(":
-				if (!inQuote) openParenCount++;
-				break;
-			case ")":
-				if (!inQuote) openParenCount--;
-				break;
-			case "\"":
-				inQuote = !inQuote;
-				break;
-			case ",":
-				if (!inQuote && !openBraceCount && openParenCount == 1) {
-					result.push(ParameterInformation.create([currentParamStart,idx]));
-					currentParamStart = idx + 1;
-				}
-		}
-	});
-	result.push(ParameterInformation.create([currentParamStart,formalSpec.length - 1]));
-	return result;
+		.replace(new RegExp(emphasizePrefix, "g"), "<b><i><u>")
+		.replace(new RegExp(emphasizeSuffix, "g"), "</u></i></b>") + "\n</pre>";
 }
 
 export async function onSignatureHelp(params: SignatureHelpParams): Promise<SignatureHelp | null> {
-	if (params.context === undefined) {return null;}
+	if (params.context === undefined) { return null; }
 	const doc = documents.get(params.textDocument.uri);
-	if (doc === undefined) {return null;}
+	if (doc === undefined) { return null; }
 	const parsed = await getParsedDocument(params.textDocument.uri);
-	if (parsed === undefined) {return null;}
+	if (parsed === undefined) { return null; }
 	const server: ServerSpec = await getServerSpec(params.textDocument.uri);
 	const settings = await getLanguageServerSettings(params.textDocument.uri);
 
 	if (params.context.triggerKind == SignatureHelpTriggerKind.Invoked) {
 		// We always base our return value on the triggerCharacter
-		params.context.triggerCharacter = doc.getText(Range.create(Position.create(params.position.line,params.position.character-1),params.position));
+		params.context.triggerCharacter = doc.getText(Range.create(Position.create(params.position.line, params.position.character - 1), params.position));
 	}
 
 	let thistoken: number = -1;
 	for (let i = 0; i < parsed[params.position.line].length; i++) {
 		const symbolstart: number = parsed[params.position.line][i].p;
-		const symbolend: number =  parsed[params.position.line][i].p + parsed[params.position.line][i].c;
+		const symbolend: number = parsed[params.position.line][i].p + parsed[params.position.line][i].c;
 		thistoken = i;
 		if (params.position.character >= symbolstart && params.position.character <= symbolend) {
 			// We found the right symbol in the line
@@ -152,10 +120,10 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 		// Only compute signature help in ObjectScript
 		(triggerlang != ld.cos_langindex) ||
 		// Don't compute signature help inside of a string literal
-		((doc.getText(Range.create(Position.create(params.position.line,0),params.position)).split("\"").length - 1) % 2 == 1)
+		((doc.getText(Range.create(Position.create(params.position.line, 0), params.position)).split("\"").length - 1) % 2 == 1)
 	) {
 		if (params.context.activeSignatureHelp) {
-			params.context.activeSignatureHelp.signatures[0].documentation = signatureHelpDocumentationCache.doc;
+			params.context.activeSignatureHelp.signatures[0].documentation = signatureHelpDocumentationCache?.doc;
 			return params.context.activeSignatureHelp;
 		} else {
 			return null;
@@ -164,7 +132,7 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 
 	if (params.context.isRetrigger && (params.context.triggerCharacter !== "(")) {
 		if (params.context.activeSignatureHelp !== undefined && signatureHelpStartPosition !== undefined) {
-			const prevchar = doc.getText(Range.create(Position.create(params.position.line,params.position.character-1),params.position));
+			const prevchar = doc.getText(Range.create(Position.create(params.position.line, params.position.character - 1), params.position));
 			if (prevchar === ")") {
 				// The user closed the signature
 				signatureHelpDocumentationCache = undefined;
@@ -173,16 +141,17 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 			}
 
 			// Determine the active parameter
-			params.context.activeSignatureHelp.activeParameter = determineActiveParam(doc.getText(Range.create(signatureHelpStartPosition,params.position)));
+			params.context.activeSignatureHelp.activeParameter = determineActiveParam(doc.getText(Range.create(signatureHelpStartPosition, params.position)));
 
 			if (signatureHelpDocumentationCache !== undefined) {
+				const signatureInfo = params.context.activeSignatureHelp.signatures[0];
 				if (signatureHelpDocumentationCache.type === "macro" && params.context.activeSignatureHelp.activeParameter !== null) {
 					// This is a macro with active parameter
 
 					// Get the macro expansion with the next parameter emphasized
-					var expinputdata = {...signatureHelpMacroCache};
-					expinputdata.arguments = emphasizeArgument(expinputdata.arguments,params.context.activeSignatureHelp.activeParameter+1);
-					const exprespdata = await makeRESTRequest("POST",2,"/action/getmacroexpansion",server,expinputdata)
+					var expinputdata = { ...signatureHelpMacroCache };
+					expinputdata.arguments = emphasizeArgument(expinputdata.arguments, params.context.activeSignatureHelp.activeParameter + 1);
+					const exprespdata = await makeRESTRequest("POST", 2, "/action/getmacroexpansion", server, expinputdata)
 					if (exprespdata !== undefined && exprespdata.data.result.content.expansion.length > 0) {
 						signatureHelpDocumentationCache.doc = {
 							kind: MarkupKind.Markdown,
@@ -190,6 +159,23 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 						};
 						params.context.activeSignatureHelp.signatures[0].documentation = signatureHelpDocumentationCache.doc;
 					}
+				}
+				else if (signatureHelpDocumentationCache.type === "routine") {
+					const paramInfos = signatureInfo.parameters ?? [];
+					const boundedIndex = paramInfos.length
+						? Math.min(
+							Math.max(params.context.activeSignatureHelp.activeParameter ?? 0, 0),
+							paramInfos.length - 1
+						)
+						: null;
+					params.context.activeSignatureHelp.activeParameter = boundedIndex;
+					const docContent = buildRoutineDocumentation(
+						signatureInfo,
+						boundedIndex,
+						{ context: 'signature' }
+					);
+					signatureHelpDocumentationCache.doc = docContent;
+					signatureInfo.documentation = docContent;
 				}
 				else {
 					// This is a method or a macro without an active parameter
@@ -206,20 +192,20 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 
 	if (
 		params.context.triggerCharacter == "(" && triggerlang === ld.cos_langindex &&
-		![ld.cos_comment_attrindex,ld.cos_dcom_attrindex,ld.cos_str_attrindex].includes(triggerattr) &&
+		![ld.cos_comment_attrindex, ld.cos_dcom_attrindex, ld.cos_str_attrindex].includes(triggerattr) &&
 		thistoken > 0
 	) {
 		// This is potentially the start of a signature
 
 		var newsignature: SignatureHelp | null = null;
-		if (parsed[params.position.line][thistoken-1].l == ld.cos_langindex && parsed[params.position.line][thistoken-1].s == ld.cos_macro_attrindex) {
+		if (parsed[params.position.line][thistoken - 1].l == ld.cos_langindex && parsed[params.position.line][thistoken - 1].s == ld.cos_macro_attrindex) {
 			// This is a macro
 
 			// Get the details of this class
-			const maccon = getMacroContext(doc,parsed,params.position.line);
+			const maccon = getMacroContext(doc, parsed, params.position.line);
 
 			// Get the full range of the macro
-			const macrorange = findFullRange(params.position.line,parsed,thistoken-1,parsed[params.position.line][thistoken-1].p,parsed[params.position.line][thistoken-1].p+parsed[params.position.line][thistoken-1].c);
+			const macrorange = findFullRange(params.position.line, parsed, thistoken - 1, parsed[params.position.line][thistoken - 1].p, parsed[params.position.line][thistoken - 1].p + parsed[params.position.line][thistoken - 1].c);
 			const macroname = doc.getText(macrorange).slice(3);
 
 			// Get the macro signature from the server
@@ -232,10 +218,10 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 				imports: maccon.imports,
 				mode: maccon.mode
 			};
-			const respdata = await makeRESTRequest("POST",2,"/action/getmacrosignature",server,inputdata);
+			const respdata = await makeRESTRequest("POST", 2, "/action/getmacrosignature", server, inputdata);
 			if (respdata !== undefined && respdata.data.result.content.signature !== "") {
 				// The macro signature was found
-				const sigtext = respdata.data.result.content.signature.replace(/\s+/g,"").replace(/,/g,", ");
+				const sigtext = respdata.data.result.content.signature.replace(/\s+/g, "").replace(/,/g, ", ");
 				const sig: SignatureInformation = {
 					label: sigtext,
 					parameters: formalSpecToParamsArr(sigtext)
@@ -252,9 +238,9 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 					mode: maccon.mode,
 					arguments: sig.label
 				};
-				var expinputdata = {...signatureHelpMacroCache};
-				expinputdata.arguments = emphasizeArgument(sig.label,1);
-				const exprespdata = await makeRESTRequest("POST",2,"/action/getmacroexpansion",server,expinputdata)
+				var expinputdata = { ...signatureHelpMacroCache };
+				expinputdata.arguments = emphasizeArgument(sig.label, 1);
+				const exprespdata = await makeRESTRequest("POST", 2, "/action/getmacroexpansion", server, expinputdata)
 				if (exprespdata !== undefined && exprespdata.data.result.content.expansion.length > 0) {
 					signatureHelpDocumentationCache = {
 						type: "macro",
@@ -274,20 +260,20 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 			}
 		}
 		else if (
-			parsed[params.position.line][thistoken-1].l == ld.cos_langindex && 
-			(parsed[params.position.line][thistoken-1].s == ld.cos_method_attrindex || parsed[params.position.line][thistoken-1].s == ld.cos_mem_attrindex)
+			parsed[params.position.line][thistoken - 1].l == ld.cos_langindex &&
+			(parsed[params.position.line][thistoken - 1].s == ld.cos_method_attrindex || parsed[params.position.line][thistoken - 1].s == ld.cos_mem_attrindex)
 		) {
 			// This is a method or multidimensional property
 
 			// Get the full text of the member
 			const member = doc.getText(Range.create(
-				params.position.line,parsed[params.position.line][thistoken-1].p,
-				params.position.line,parsed[params.position.line][thistoken-1].p+parsed[params.position.line][thistoken-1].c
+				params.position.line, parsed[params.position.line][thistoken - 1].p,
+				params.position.line, parsed[params.position.line][thistoken - 1].p + parsed[params.position.line][thistoken - 1].c
 			));
-			const unquotedname = quoteUDLIdentifier(member,0);
+			const unquotedname = quoteUDLIdentifier(member, 0);
 
 			// Get the base class that this member is in
-			const membercontext = await getClassMemberContext(doc,parsed,thistoken-2,params.position.line,server);
+			const membercontext = await getClassMemberContext(doc, parsed, thistoken - 2, params.position.line, server);
 			if (membercontext.baseclass === "") {
 				// If we couldn't determine the class, don't return anything
 				return null;
@@ -297,20 +283,21 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 			const querydata = member == "%New" ? {
 				// Get the information for both %New and %OnNew
 				query: "SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
-				parameters: [membercontext.baseclass,unquotedname,"%OnNew"]
+				parameters: [membercontext.baseclass, unquotedname, "%OnNew"]
 			} : {
 				query: "SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
-				parameters: [membercontext.baseclass,unquotedname]
+				parameters: [membercontext.baseclass, unquotedname]
 			};
-			const respdata = await makeRESTRequest("POST",1,"/action/query",server,querydata);
+			const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
 			if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 				// We got data back
 
 				if (member == "%New") {
 					if (respdata.data.result.content.length == 2 && respdata.data.result.content[1].Origin != "%Library.RegisteredObject") {
 						// %OnNew has been overridden for this class
+						const raw = beautifyFormalSpec(respdata.data.result.content[1].FormalSpec);
 						const sig: SignatureInformation = {
-							label: beautifyFormalSpec(respdata.data.result.content[1].FormalSpec),
+							label: raw,
 							parameters: []
 						};
 						if (settings.signaturehelp.documentation) {
@@ -325,8 +312,8 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 							};
 							sig.documentation = signatureHelpDocumentationCache.doc;
 						}
-						
-						sig.parameters = formalSpecToParamsArr(sig.label);
+
+						sig.parameters = formalSpecToParamsArr(raw);
 						sig.label += ` As ${membercontext.baseclass}`;
 						signatureHelpStartPosition = params.position;
 						newsignature = {
@@ -361,9 +348,9 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 							stubquery = "SELECT Description, FormalSpec, ReturnType FROM %Dictionary.CompiledConstraintMethod WHERE Name = ? AND parent->Parent = ? AND parent->Name = ?";
 						}
 						if (stubquery !== "") {
-							const stubrespdata = await makeRESTRequest("POST",1,"/action/query",server,{
+							const stubrespdata = await makeRESTRequest("POST", 1, "/action/query", server, {
 								query: stubquery,
-								parameters: [stubarr[1],membercontext.baseclass,stubarr[0]]
+								parameters: [stubarr[1], membercontext.baseclass, stubarr[0]]
 							});
 							if (Array.isArray(stubrespdata?.data?.result?.content) && stubrespdata.data.result.content.length > 0) {
 								// We got data back
@@ -373,8 +360,9 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 					}
 
 					if (memobj.FormalSpec !== "") {
+						const raw = beautifyFormalSpec(memobj.FormalSpec);
 						const sig: SignatureInformation = {
-							label: beautifyFormalSpec(memobj.FormalSpec),
+							label: raw,
 							parameters: []
 						};
 						if (settings.signaturehelp.documentation) {
@@ -387,9 +375,9 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 							};
 							sig.documentation = signatureHelpDocumentationCache.doc;
 						}
-						
-						sig.parameters = formalSpecToParamsArr(sig.label);
-						if (["%Open","%OpenId"].includes(member)) {
+
+						sig.parameters = formalSpecToParamsArr(raw);
+						if (["%Open", "%OpenId"].includes(member)) {
 							sig.label += ` As ${membercontext.baseclass}`;
 						} else if (memobj.ReturnType != "") {
 							sig.label += ` As ${memobj.ReturnType}`;
@@ -404,6 +392,35 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 				}
 			}
 		}
+		if (newsignature === null) {
+			const routineDetails = await getRoutineSignatureDetails(
+				doc,
+				parsed,
+				params.position.line,
+				thistoken,
+				params.textDocument.uri,
+				server
+			);
+			if (routineDetails !== null) {
+				const initialActive = routineDetails.signature.parameters.length ? 0 : null;
+				const initialDoc = buildRoutineDocumentation(
+					routineDetails.signature,
+					initialActive,
+					{ context: 'signature' }
+				);
+				signatureHelpDocumentationCache = {
+					type: "routine",
+					doc: initialDoc
+				};
+				routineDetails.signature.documentation = initialDoc;
+				signatureHelpStartPosition = routineDetails.start;
+				newsignature = {
+					signatures: [routineDetails.signature],
+					activeSignature: 0,
+					activeParameter: initialActive
+				};
+			}
+		}
 		if (newsignature !== null) {
 			return newsignature;
 		}
@@ -416,26 +433,27 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 	}
 	else if (
 		!params.context.isRetrigger &&
-		params.context.triggerCharacter == "," && triggerlang === ld.cos_langindex &&
-		![ld.cos_comment_attrindex,ld.cos_dcom_attrindex,ld.cos_str_attrindex].includes(triggerattr)
+		triggerlang === ld.cos_langindex &&
+		![ld.cos_comment_attrindex, ld.cos_dcom_attrindex, ld.cos_str_attrindex].includes(triggerattr) &&
+		(params.context.triggerCharacter == "," || params.context.triggerKind == SignatureHelpTriggerKind.Invoked)
 	) {
 		// This is potentially the argument list for a signature
 
 		// Loop backwards in the file and look for the first open parenthesis that isn't closed
-		const [sigstartln, sigstarttkn] = findOpenParen(doc,parsed,params.position.line,thistoken);
+		const [sigstartln, sigstarttkn] = findOpenParen(doc, parsed, params.position.line, thistoken);
 
 		if (sigstartln !== -1 && sigstarttkn !== -1) {
 			// We found an open parenthesis token that wasn't closed
 
 			// Check the language and attribute of the token before the "("
-			if (parsed[sigstartln][sigstarttkn-1].l == ld.cos_langindex && parsed[sigstartln][sigstarttkn-1].s == ld.cos_macro_attrindex) {
+			if (parsed[sigstartln][sigstarttkn - 1].l == ld.cos_langindex && parsed[sigstartln][sigstarttkn - 1].s == ld.cos_macro_attrindex) {
 				// This is a macro
 
 				// Get the details of this class
-				const maccon = getMacroContext(doc,parsed,sigstartln);
+				const maccon = getMacroContext(doc, parsed, sigstartln);
 
 				// Get the full range of the macro
-				const macrorange = findFullRange(sigstartln,parsed,sigstarttkn-1,parsed[sigstartln][sigstarttkn-1].p,parsed[sigstartln][sigstarttkn-1].p+parsed[sigstartln][sigstarttkn-1].c);
+				const macrorange = findFullRange(sigstartln, parsed, sigstarttkn - 1, parsed[sigstartln][sigstarttkn - 1].p, parsed[sigstartln][sigstarttkn - 1].p + parsed[sigstartln][sigstarttkn - 1].c);
 				const macroname = doc.getText(macrorange).slice(3);
 
 				// Get the macro signature from the server
@@ -448,17 +466,21 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 					imports: maccon.imports,
 					mode: maccon.mode
 				};
-				const respdata = await makeRESTRequest("POST",2,"/action/getmacrosignature",server,inputdata);
+				const respdata = await makeRESTRequest("POST", 2, "/action/getmacrosignature", server, inputdata);
 				if (respdata !== undefined && respdata.data.result.content.signature !== "") {
 					// The macro signature was found
-					const sigtext = respdata.data.result.content.signature.replace(/\s+/g,"").replace(/,/g,", ");
+					const sigtext = respdata.data.result.content.signature.replace(/\s+/g, "").replace(/,/g, ", ");
 					const sig: SignatureInformation = {
 						label: sigtext,
 						parameters: formalSpecToParamsArr(sigtext)
 					};
 
 					// Determine the active parameter
-					var activeparam = determineActiveParam(doc.getText(Range.create(Position.create(sigstartln,parsed[sigstartln][sigstarttkn].p+1),params.position)));
+					var activeparam = determineActiveParam(doc.getText(Range.create(Position.create(sigstartln, parsed[sigstartln][sigstarttkn].p + 1), params.position)));
+					const macroParamCount = sig.parameters?.length ?? 0;
+					if (macroParamCount > 0 && activeparam !== null) {
+						activeparam = Math.min(Math.max(activeparam, 0), macroParamCount - 1);
+					}
 
 					// Get the macro expansion with the correct parameter emphasized
 					signatureHelpMacroCache = {
@@ -471,9 +493,9 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 						mode: maccon.mode,
 						arguments: sig.label
 					};
-					var expinputdata = {...signatureHelpMacroCache};
-					expinputdata.arguments = emphasizeArgument(sig.label,activeparam+1);
-					const exprespdata = await makeRESTRequest("POST",2,"/action/getmacroexpansion",server,expinputdata)
+					var expinputdata = { ...signatureHelpMacroCache };
+					expinputdata.arguments = emphasizeArgument(sig.label, activeparam + 1);
+					const exprespdata = await makeRESTRequest("POST", 2, "/action/getmacroexpansion", server, expinputdata)
 					if (exprespdata !== undefined && exprespdata.data.result.content.expansion.length > 0) {
 						signatureHelpDocumentationCache = {
 							type: "macro",
@@ -484,7 +506,7 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 						};
 						sig.documentation = signatureHelpDocumentationCache.doc;
 					}
-					signatureHelpStartPosition = Position.create(sigstartln,parsed[sigstartln][sigstarttkn].p+1);
+					signatureHelpStartPosition = Position.create(sigstartln, parsed[sigstartln][sigstarttkn].p + 1);
 					return {
 						signatures: [sig],
 						activeSignature: 0,
@@ -493,20 +515,20 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 				}
 			}
 			else if (
-				parsed[sigstartln][sigstarttkn-1].l == ld.cos_langindex && 
-				(parsed[sigstartln][sigstarttkn-1].s == ld.cos_method_attrindex || parsed[sigstartln][sigstarttkn-1].s == ld.cos_mem_attrindex)
+				parsed[sigstartln][sigstarttkn - 1].l == ld.cos_langindex &&
+				(parsed[sigstartln][sigstarttkn - 1].s == ld.cos_method_attrindex || parsed[sigstartln][sigstarttkn - 1].s == ld.cos_mem_attrindex)
 			) {
 				// This is a method or multidimensional property
-				
+
 				// Get the full text of the member
 				const member = doc.getText(Range.create(
-					sigstartln,parsed[sigstartln][sigstarttkn-1].p,
-					sigstartln,parsed[sigstartln][sigstarttkn-1].p+parsed[sigstartln][sigstarttkn-1].c
+					sigstartln, parsed[sigstartln][sigstarttkn - 1].p,
+					sigstartln, parsed[sigstartln][sigstarttkn - 1].p + parsed[sigstartln][sigstarttkn - 1].c
 				));
-				const unquotedname = quoteUDLIdentifier(member,0);
+				const unquotedname = quoteUDLIdentifier(member, 0);
 
 				// Get the base class that this member is in
-				const membercontext = await getClassMemberContext(doc,parsed,sigstarttkn-2,sigstartln,server);
+				const membercontext = await getClassMemberContext(doc, parsed, sigstarttkn - 2, sigstartln, server);
 				if (membercontext.baseclass === "") {
 					// If we couldn't determine the class, don't return anything
 					return null;
@@ -516,20 +538,21 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 				const querydata = member == "%New" ? {
 					// Get the information for both %New and %OnNew
 					query: "SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
-					parameters: [membercontext.baseclass,unquotedname,"%OnNew"]
+					parameters: [membercontext.baseclass, unquotedname, "%OnNew"]
 				} : {
 					query: "SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
-					parameters: [membercontext.baseclass,unquotedname]
+					parameters: [membercontext.baseclass, unquotedname]
 				};
-				const respdata = await makeRESTRequest("POST",1,"/action/query",server,querydata);
+				const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
 				if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 					// We got data back
 
 					if (member == "%New") {
 						if (respdata.data.result.content.length == 2 && respdata.data.result.content[1].Origin != "%Library.RegisteredObject") {
 							// %OnNew has been overridden for this class
+							const raw = beautifyFormalSpec(respdata.data.result.content[1].FormalSpec);
 							const sig: SignatureInformation = {
-								label: beautifyFormalSpec(respdata.data.result.content[1].FormalSpec),
+								label: raw,
 								parameters: []
 							};
 							if (settings.signaturehelp.documentation) {
@@ -544,14 +567,19 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 								};
 								sig.documentation = signatureHelpDocumentationCache.doc;
 							}
-							
-							sig.parameters = formalSpecToParamsArr(sig.label);
+
+							sig.parameters = formalSpecToParamsArr(raw);
 							sig.label += ` As ${membercontext.baseclass}`;
-							signatureHelpStartPosition = Position.create(sigstartln,parsed[sigstartln][sigstarttkn].p+1);
+							const newActive = determineActiveParam(doc.getText(Range.create(Position.create(sigstartln, parsed[sigstartln][sigstarttkn].p + 1), params.position)));
+							const newParamCount = sig.parameters?.length ?? 0;
+							const boundedNewActive = (newParamCount > 0 && newActive !== null)
+								? Math.min(Math.max(newActive, 0), newParamCount - 1)
+								: null;
+							signatureHelpStartPosition = Position.create(sigstartln, parsed[sigstartln][sigstarttkn].p + 1);
 							newsignature = {
 								signatures: [sig],
 								activeSignature: 0,
-								activeParameter: determineActiveParam(doc.getText(Range.create(Position.create(sigstartln,parsed[sigstartln][sigstarttkn].p+1),params.position)))
+								activeParameter: boundedNewActive
 							};
 						} else {
 							// If there's no %OnNew, then %New shouldn't have arguments
@@ -580,9 +608,9 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 								stubquery = "SELECT Description, FormalSpec, ReturnType FROM %Dictionary.CompiledConstraintMethod WHERE Name = ? AND parent->Parent = ? AND parent->Name = ?";
 							}
 							if (stubquery !== "") {
-								const stubrespdata = await makeRESTRequest("POST",1,"/action/query",server,{
+								const stubrespdata = await makeRESTRequest("POST", 1, "/action/query", server, {
 									query: stubquery,
-									parameters: [stubarr[1],membercontext.baseclass,stubarr[0]]
+									parameters: [stubarr[1], membercontext.baseclass, stubarr[0]]
 								});
 								if (Array.isArray(stubrespdata?.data?.result?.content) && stubrespdata.data.result.content.length > 0) {
 									// We got data back
@@ -592,8 +620,9 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 						}
 
 						if (memobj.FormalSpec !== "") {
+							const raw = beautifyFormalSpec(memobj.FormalSpec);
 							const sig: SignatureInformation = {
-								label: beautifyFormalSpec(memobj.FormalSpec),
+								label: raw,
 								parameters: []
 							};
 							if (settings.signaturehelp.documentation) {
@@ -606,22 +635,69 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 								};
 								sig.documentation = signatureHelpDocumentationCache.doc;
 							}
-							
-							sig.parameters = formalSpecToParamsArr(sig.label);
-							if (["%Open","%OpenId"].includes(member)) {
+
+							sig.parameters = formalSpecToParamsArr(raw);
+							const methodActive = determineActiveParam(doc.getText(Range.create(Position.create(sigstartln, parsed[sigstartln][sigstarttkn].p + 1), params.position)));
+							const methodParamCount = sig.parameters?.length ?? 0;
+							const boundedMethodActive = (methodParamCount > 0 && methodActive !== null)
+								? Math.min(Math.max(methodActive, 0), methodParamCount - 1)
+								: null;
+							if (["%Open", "%OpenId"].includes(member)) {
 								sig.label += ` As ${membercontext.baseclass}`;
 							} else if (memobj.ReturnType != "") {
 								sig.label += ` As ${memobj.ReturnType}`;
 							}
 
-							signatureHelpStartPosition = Position.create(sigstartln,parsed[sigstartln][sigstarttkn].p+1);
+							signatureHelpStartPosition = Position.create(sigstartln, parsed[sigstartln][sigstarttkn].p + 1);
 							return {
 								signatures: [sig],
 								activeSignature: 0,
-								activeParameter: determineActiveParam(doc.getText(Range.create(Position.create(sigstartln,parsed[sigstartln][sigstarttkn].p+1),params.position)))
+								activeParameter: boundedMethodActive
 							};
 						}
 					}
+				}
+			}
+			else {
+				const routineDetails = await getRoutineSignatureDetails(
+					doc,
+					parsed,
+					sigstartln,
+					sigstarttkn,
+					params.textDocument.uri,
+					server
+				);
+				if (routineDetails !== null) {
+					const startPos = routineDetails.start;
+					const beforeStart = (
+						params.position.line < startPos.line ||
+						(params.position.line == startPos.line && params.position.character < startPos.character)
+					);
+					const activeParamValue = beforeStart
+						? 0
+						: determineActiveParam(doc.getText(Range.create(startPos, params.position)));
+					const boundedIndex = routineDetails.signature.parameters.length
+						? Math.min(
+							Math.max((activeParamValue ?? 0), 0),
+							routineDetails.signature.parameters.length - 1
+						)
+						: null;
+					const docContent = buildRoutineDocumentation(
+						routineDetails.signature,
+						boundedIndex,
+						{ context: 'signature' }
+					);
+					signatureHelpDocumentationCache = {
+						type: "routine",
+						doc: docContent
+					};
+					routineDetails.signature.documentation = docContent;
+					signatureHelpStartPosition = startPos;
+					return {
+						signatures: [routineDetails.signature],
+						activeSignature: 0,
+						activeParameter: boundedIndex
+					};
 				}
 			}
 		}

--- a/server/src/utils/types.ts
+++ b/server/src/utils/types.ts
@@ -55,11 +55,11 @@ export type StudioOpenDialogFile = {
  * Schema of an element in the command documentation file.
  */
 export type CommandDoc = {
-    label: string;
-    alias: string[];
-    documentation: string[];
-    link: string;
-    insertText?: string;
+	label: string;
+	alias: string[];
+	documentation: string[];
+	link: string;
+	insertText?: string;
 };
 
 /**
@@ -144,8 +144,8 @@ export type SignatureHelpMacroContext = {
  * The content of the last SignatureHelp documentation sent and the type of signature that it applies to.
  */
 export type SignatureHelpDocCache = {
-	doc: MarkupContent,
-	type: "macro" | "method"
+	doc: MarkupContent | undefined,
+	type: "macro" | "method" | "routine"
 };
 
 /**
@@ -159,15 +159,15 @@ export type PossibleClasses = {
 
 export type compresseditem = {
 	/** The numerical index of the language. */
-    l: number;
-    /** The index of the attribute within the array returned by `GetLanguageAttributes()`. */
-    s: number;
-    /** The starting position of this token in the source line. */
-    p: number;
-    /** The length of this token's source. */
-    c: number;
-    /** A short description of the syntax error. It will only be defined if `l` is `1` (ObjectScript) and `s` is `0`. */
-    e?: string;
+	l: number;
+	/** The index of the attribute within the array returned by `GetLanguageAttributes()`. */
+	s: number;
+	/** The starting position of this token in the source line. */
+	p: number;
+	/** The length of this token's source. */
+	c: number;
+	/** A short description of the syntax error. It will only be defined if `l` is `1` (ObjectScript) and `s` is `0`. */
+	e?: string;
 };
 
 export type compressedline = compresseditem[];


### PR DESCRIPTION
- Unified layout for Hover and Signature Help
    - Both now use the same inline code format to highlight the active parameter.
    - The hover display now uses a normal font size (avoiding VS Code’s enlarged header effect).
    
- New options in buildRoutineDocumentation:
    - context: 'hover' | 'signature' → defines behavior and display per context.
    - boldParameter?: boolean → optionally renders the active parameter in bold.
    - showHeaderInHover?: boolean → controls whether to show the code block header in hover.
    
- Context-specific behaviors:
    - Hover: shows the routine header, the “signature-like” line, and the “Parameter in source” line.
    - Signature Help: only shows “Parameter in source”, removing the middle signature block.
    - Prevents large header font in hover by adding a zero-width space (\u200B) at the start.
    
- Improved compatibility and safety
    - Safe HTML escaping for <, >, and & characters.